### PR TITLE
Enforces authorization for project deletion

### DIFF
--- a/src/Infrastructure/Event/CompositeEventSerializer.php
+++ b/src/Infrastructure/Event/CompositeEventSerializer.php
@@ -46,6 +46,6 @@ final readonly class CompositeEventSerializer implements EventSerializer
 
     public function supports(string $eventType): bool
     {
-        return array_any($this->serializers, fn($serializer): bool => $serializer->supports($eventType));
+        return array_any($this->serializers, fn ($serializer): bool => $serializer->supports($eventType));
     }
 }

--- a/src/Infrastructure/Http/Dto/DeleteProjectRequestDto.php
+++ b/src/Infrastructure/Http/Dto/DeleteProjectRequestDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class DeleteProjectRequestDto
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Uuid]
+        public string $userId,
+    ) {
+    }
+}

--- a/src/Infrastructure/Persistence/EventStore/ProjectEventStoreRepository.php
+++ b/src/Infrastructure/Persistence/EventStore/ProjectEventStoreRepository.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\EventStore;
 
-use App\Project\Domain\Model\ProjectSnapshot;
 use App\Project\Domain\Model\Project;
+use App\Project\Domain\Model\ProjectSnapshot;
 use App\Project\Domain\Model\ProjectSnapshotFactory;
 use App\Project\Domain\Repository\ProjectRepositoryInterface;
 use App\Shared\Domain\Model\AggregateSnapshot;

--- a/src/Project/Application/Command/Delete/DeleteOrphanedProjectsHandler.php
+++ b/src/Project/Application/Command/Delete/DeleteOrphanedProjectsHandler.php
@@ -30,7 +30,7 @@ final readonly class DeleteOrphanedProjectsHandler
             $project = $this->projectRepository->load(Uuid::create($readModel->getId()));
 
             if ($project instanceof Project) {
-                $project->delete();
+                $project->delete($uuid);
                 $this->projectRepository->save($project);
             }
         }

--- a/src/Project/Application/Command/Delete/DeleteProjectCommand.php
+++ b/src/Project/Application/Command/Delete/DeleteProjectCommand.php
@@ -10,6 +10,7 @@ final readonly class DeleteProjectCommand
 {
     private function __construct(
         private Uuid $projectId,
+        private Uuid $userId,
     ) {
     }
 
@@ -18,8 +19,13 @@ final readonly class DeleteProjectCommand
         return $this->projectId;
     }
 
-    public static function fromPrimitives(string $projectId): self
+    public function getUserId(): Uuid
     {
-        return new self(Uuid::create($projectId));
+        return $this->userId;
+    }
+
+    public static function fromPrimitives(string $projectId, string $userId): self
+    {
+        return new self(Uuid::create($projectId), Uuid::create($userId));
     }
 }

--- a/src/Project/Application/Command/Delete/DeleteProjectHandler.php
+++ b/src/Project/Application/Command/Delete/DeleteProjectHandler.php
@@ -23,7 +23,7 @@ final readonly class DeleteProjectHandler
             throw new ProjectNotFoundException($deleteProjectCommand->getProjectId());
         }
 
-        $deletedProject = $project->delete();
+        $deletedProject = $project->delete($deleteProjectCommand->getUserId());
         $this->projectRepository->save($deletedProject);
 
         return $deletedProject;

--- a/src/Project/Application/Query/Get/GetProjectHistoryHandler.php
+++ b/src/Project/Application/Query/Get/GetProjectHistoryHandler.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Project\Application\Query\Get;
 
-use App\Shared\Domain\Event\DomainEvent;
 use App\Project\Application\Mapper\ProjectDtoMapperInterface;
 use App\Project\Domain\Model\Project;
 use App\Project\Domain\Repository\ProjectRepositoryInterface;
+use App\Shared\Domain\Event\DomainEvent;
 use App\Shared\Event\EventStore;
 
 final readonly class GetProjectHistoryHandler

--- a/src/Project/Domain/Model/Project.php
+++ b/src/Project/Domain/Model/Project.php
@@ -76,10 +76,14 @@ final class Project extends AggregateRoot
         return $this->deletedAt instanceof DateTimeImmutable;
     }
 
-    public function delete(): self
+    public function delete(Uuid $requestingUserId): self
     {
         if ($this->isDeleted()) {
             throw new DomainException('Project is already deleted');
+        }
+
+        if (!$this->ownerId->equals($requestingUserId)) {
+            throw new DomainException('Only project owner can delete the project');
         }
 
         $this->apply(new ProjectDeletedEvent($this->getId()));

--- a/src/Project/Infrastructure/Mapper/ProjectDtoMapper.php
+++ b/src/Project/Infrastructure/Mapper/ProjectDtoMapper.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Project\Infrastructure\Mapper;
 
-use App\Project\Domain\ValueObject\ProjectWorker;
 use App\Project\Application\Mapper\ProjectDtoMapperInterface;
 use App\Project\Domain\Model\Project;
+use App\Project\Domain\ValueObject\ProjectWorker;
 
 final readonly class ProjectDtoMapper implements ProjectDtoMapperInterface
 {

--- a/src/Project/Infrastructure/Projection/ProjectReadModelProjection.php
+++ b/src/Project/Infrastructure/Projection/ProjectReadModelProjection.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace App\Project\Infrastructure\Projection;
 
-use App\Project\Domain\Model\Project;
-use App\Shared\ValueObject\Uuid;
-use App\Project\Domain\ValueObject\ProjectWorker;
 use App\Project\Application\Projection\ProjectReadModelProjectionInterface;
+use App\Project\Domain\Model\Project;
 use App\Project\Domain\Repository\ProjectRepositoryInterface;
+use App\Project\Domain\ValueObject\ProjectWorker;
 use App\Project\Infrastructure\Persistence\ReadModel\ProjectReadModelEntity;
 use App\Project\Infrastructure\Persistence\ReadModel\ProjectReadModelRepository;
 use App\Shared\Domain\Event\DomainEvent;
+use App\Shared\ValueObject\Uuid;
 use DateTimeInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;

--- a/tests/Feature/ProjectHttpTest.php
+++ b/tests/Feature/ProjectHttpTest.php
@@ -133,7 +133,11 @@ it('can delete project via HTTP API', function (): void {
     expect($client->getResponse()->getStatusCode())->toBe(Response::HTTP_OK);
 
     // Delete the project
-    $client->request('DELETE', '/api/projects/'.$projectId);
+    $client->request('DELETE', '/api/projects/'.$projectId, [], [], [
+        'CONTENT_TYPE' => 'application/json',
+    ], json_encode([
+        'userId' => $user->getId()->toString(),
+    ]));
 
     expect($client->getResponse()->getStatusCode())->toBe(Response::HTTP_NO_CONTENT);
 
@@ -320,11 +324,19 @@ it('prevents double deletion of project via HTTP API', function (): void {
     $projectId = $project->getId()->toString();
 
     // Delete the project first time
-    $client->request('DELETE', '/api/projects/'.$projectId);
+    $client->request('DELETE', '/api/projects/'.$projectId, [], [], [
+        'CONTENT_TYPE' => 'application/json',
+    ], json_encode([
+        'userId' => '550e8400-e29b-41d4-a716-446655440001',
+    ]));
     expect($client->getResponse()->getStatusCode())->toBe(Response::HTTP_NO_CONTENT);
 
     // Try to delete the project second time - should return error
-    $client->request('DELETE', '/api/projects/'.$projectId);
+    $client->request('DELETE', '/api/projects/'.$projectId, [], [], [
+        'CONTENT_TYPE' => 'application/json',
+    ], json_encode([
+        'userId' => '550e8400-e29b-41d4-a716-446655440001',
+    ]));
     expect($client->getResponse()->getStatusCode())->toBe(Response::HTTP_INTERNAL_SERVER_ERROR);
 });
 
@@ -341,7 +353,11 @@ it('cannot rename deleted project via HTTP API', function (): void {
     $projectId = $project->getId()->toString();
 
     // Delete the project
-    $client->request('DELETE', '/api/projects/'.$projectId);
+    $client->request('DELETE', '/api/projects/'.$projectId, [], [], [
+        'CONTENT_TYPE' => 'application/json',
+    ], json_encode([
+        'userId' => '550e8400-e29b-41d4-a716-446655440001',
+    ]));
     expect($client->getResponse()->getStatusCode())->toBe(Response::HTTP_NO_CONTENT);
 
     // Try to rename the deleted project
@@ -367,7 +383,11 @@ it('cannot add worker to deleted project via HTTP API', function (): void {
     $projectId = $project->getId()->toString();
 
     // Delete the project
-    $client->request('DELETE', '/api/projects/'.$projectId);
+    $client->request('DELETE', '/api/projects/'.$projectId, [], [], [
+        'CONTENT_TYPE' => 'application/json',
+    ], json_encode([
+        'userId' => '550e8400-e29b-41d4-a716-446655440001',
+    ]));
     expect($client->getResponse()->getStatusCode())->toBe(Response::HTTP_NO_CONTENT);
 
     // Try to add worker to deleted project

--- a/tests/Project/Doubles/InMemoryEventDispatcher.php
+++ b/tests/Project/Doubles/InMemoryEventDispatcher.php
@@ -44,7 +44,7 @@ final class InMemoryEventDispatcher implements EventDispatcher
 
     public function hasEventOfType(string $eventClass): bool
     {
-        return array_any($this->dispatchedEvents, fn($dispatchedEvent): bool => $dispatchedEvent instanceof $eventClass);
+        return array_any($this->dispatchedEvents, fn ($dispatchedEvent): bool => $dispatchedEvent instanceof $eventClass);
     }
 
     public function clear(): void

--- a/tests/Project/Integration/ProjectEventStoreIntegrationTest.php
+++ b/tests/Project/Integration/ProjectEventStoreIntegrationTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Project\Domain\ValueObject\ProjectWorker;
 use App\Infrastructure\Persistence\EventStore\ProjectEventStoreRepository;
 use App\Project\Application\Command\Register\RegisterProjectHandler;
 use App\Project\Application\Command\Rename\RenameProjectCommand;
@@ -13,6 +12,7 @@ use App\Project\Domain\Event\ProjectCreatedEvent;
 use App\Project\Domain\Event\ProjectRenamedEvent;
 use App\Project\Domain\Event\ProjectWorkerAddedEvent;
 use App\Project\Domain\Model\ProjectSnapshotFactory;
+use App\Project\Domain\ValueObject\ProjectWorker;
 use App\Tests\Project\Doubles\InMemoryEventDispatcher;
 use App\Tests\Project\Doubles\InMemoryEventStore;
 use App\Tests\Project\Doubles\InMemorySnapshotStore;

--- a/tests/Project/Integration/ProjectIntegrationTest.php
+++ b/tests/Project/Integration/ProjectIntegrationTest.php
@@ -54,7 +54,8 @@ describe('Project Integration Tests', function (): void {
 
             // Delete project
             $deleteProjectCommand = DeleteProjectCommand::fromPrimitives(
-                (string) $project->getId()
+                (string) $project->getId(),
+                (string) $project->getOwnerId()
             );
             $deletedProject = ($this->deleteHandler)($deleteProjectCommand);
 
@@ -152,7 +153,8 @@ describe('Project Integration Tests', function (): void {
 
             // Delete project
             $deleteProjectCommand = DeleteProjectCommand::fromPrimitives(
-                (string) $project->getId()
+                (string) $project->getId(),
+                (string) $project->getOwnerId()
             );
             ($this->deleteHandler)($deleteProjectCommand);
 
@@ -178,7 +180,8 @@ describe('Project Integration Tests', function (): void {
             // Delete non-existent project
             expect(function () use ($uuid): void {
                 $deleteProjectCommand = DeleteProjectCommand::fromPrimitives(
-                    (string) $uuid
+                    (string) $uuid,
+                    (string) ProjectTestFactory::createValidUuid()
                 );
                 ($this->deleteHandler)($deleteProjectCommand);
             })->toThrow(ProjectNotFoundException::class);
@@ -212,7 +215,8 @@ describe('Project Integration Tests', function (): void {
             $project = ($this->registerHandler)($registerProjectCommand);
 
             $deleteProjectCommand = DeleteProjectCommand::fromPrimitives(
-                (string) $project->getId()
+                (string) $project->getId(),
+                (string) $project->getOwnerId()
             );
             ($this->deleteHandler)($deleteProjectCommand);
 

--- a/tests/Unit/Project/Domain/ProjectSnapshotTest.php
+++ b/tests/Unit/Project/Domain/ProjectSnapshotTest.php
@@ -133,7 +133,7 @@ final class ProjectSnapshotTest extends TestCase
         $projectName = new ProjectName('Deleted Project');
 
         $project = Project::create($projectName, $uuid);
-        $project->delete();
+        $project->delete($uuid);
 
         $version = 2;
 


### PR DESCRIPTION
Restricts project deletion to the project owner by:

- Adding a userId parameter to the delete project command.
- Validating the user's identity against the project owner.
- Introducing a DTO for the delete project request.